### PR TITLE
improve selector whitespace validation to disallow it only for multiple selectors (like tags, etc) but allow for enclosed (like attribute values)

### DIFF
--- a/src/validators/validateSelector.js
+++ b/src/validators/validateSelector.js
@@ -5,7 +5,15 @@ export default selector => {
     throw new InternalError(ERR_TYPES.INVALID_SELECTOR);
   }
 
-  if (selector.indexOf(' ') !== -1) {
+  /*
+   * Matches any spaces not inside ""
+   * e.g. `input[placeholder="First A Name"]` will not be matched
+   * however `div input[placeholder="Text"]` will find the whitespace
+   */
+  const illegalSpaceBeforeRegex = /(?<!\".+)(\s)/g;
+  const illegalSpaceAfterRegex = /(\s)(?!.+\")/g;
+
+  if (!!selector.match(illegalSpaceBeforeRegex) || !!selector.match(illegalSpaceAfterRegex)) {
     throw new InternalError(ERR_TYPES.INVALID_SELECTOR_NO_MULTI);
   }
 


### PR DESCRIPTION
Closes #11