### PR TITLE
Make command options optional in type description

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -18,9 +18,9 @@ declare namespace Cypress {
     shadowClick(options?: EventOptions): Chainable<Subject>;
     shadowContains(content: string): Chainable<Subject>;
     shadowEq(index: number): Chainable<Subject>;
-    shadowFind(selector: string, options: CommandOptions): Chainable<Subject>;
+    shadowFind(selector: string, options?: CommandOptions): Chainable<Subject>;
     shadowFirst(): Chainable<Subject>;
-    shadowGet(selector: string, options: CommandOptions): Chainable<Subject>;
+    shadowGet(selector: string, options?: CommandOptions): Chainable<Subject>;
     shadowLast(): Chainable<Subject>;
     shadowTrigger(eventName: string, eventOptions?: EventOptions): Chainable<Subject>;
     shadowType(content: string): Chainable<Subject>;


### PR DESCRIPTION
Since all EventOptions properties are optional anyways and the options are not required, the type definition should reflect this.