### PR TITLE
fix(shadowFind): fix issues with retry-ability and $.find semantics

### DIFF
--- a/src/commands/shadowFind/command.js
+++ b/src/commands/shadowFind/command.js
@@ -9,10 +9,18 @@ export default function shadowFind(subject, selector, options = {}) {
   validateOptions(options, DEFAULT_COMMAND_OPTIONS);
 
   const elGetter = () => {
-    const currentElement = subject[0].shadowRoot || subject[0];
-    const found = currentElement.querySelectorAll(selector);
+    const found = Cypress.$(selector, subject);
 
-    return found;
+    if (found.length) {
+      return found;
+    }
+
+    return Array.from(subject).reduce((result, sub) => {
+      if (sub.shadowRoot) {
+        return result.add(selector, sub.shadowRoot);
+      }
+      return result;
+    }, Cypress.$([]));
   };
 
   return resolveValue(elGetter, options).then(foundElements => {

--- a/src/validators/validateSelector.js
+++ b/src/validators/validateSelector.js
@@ -4,20 +4,4 @@ export default selector => {
   if (!selector || typeof selector !== 'string') {
     throw new InternalError(ERR_TYPES.INVALID_SELECTOR);
   }
-
-  /*
-   * Matches any spaces not inside ""
-   * e.g. `input[placeholder="First A Name"]` will not be matched
-   * however `div input[placeholder="Text"]` will find the whitespace
-   */
-  const illegalSpaceBeforeRegex = /(?<!".+)(\s)/g;
-  const illegalSpaceAfterRegex = /(\s)(?!.+")/g;
-
-  if (!!selector.match(illegalSpaceBeforeRegex) || !!selector.match(illegalSpaceAfterRegex)) {
-    throw new InternalError(ERR_TYPES.INVALID_SELECTOR_NO_MULTI);
-  }
-
-  if (selector.indexOf('@') !== -1) {
-    throw new InternalError(ERR_TYPES.INVALID_SELECTOR_NO_ALIAS);
-  }
 };


### PR DESCRIPTION
This closes #25 

This uses the jQuery selector engine (`Cypress.$`) which plays nicely with Cypress' internals and allows Cypress' "retry" logic to work as expected. This also enables the semantics of `$.find` such that you can use descendant selectors and query multiple different contexts and get a single collection back.

I have been testing this on a project which uses multiple levels of shadow dom nesting with asynchronously loaded custom components... and it works nicely. When I get time I can add tests.