### PR TITLE
fix(shadowContains): matches current subject as well as descendents

### DIFF
--- a/src/commands/shadowContains/command.js
+++ b/src/commands/shadowContains/command.js
@@ -11,7 +11,7 @@ export default function shadowContains(subject, content, options = {}) {
   const selector = `:contains(${content})`;
 
   const elGetter = () => {
-    const found = Cypress.$(selector, subject);
+    const found = subject.is(selector) ? subject : Cypress.$(selector, subject);
 
     if (found.length) {
       return found;


### PR DESCRIPTION
closes #30 

I introduced a regression in #28 because I did not know that `.contains` also matches the current subject on which it is called. 