### PR TITLE
fix(shadowType): dispatch input events

### DIFF
--- a/src/commands/shadowType/command.js
+++ b/src/commands/shadowType/command.js
@@ -35,16 +35,30 @@ export default (subject, text, options = {}) => {
 
           /* eslint-disable-next-line no-param-reassign */
           subject[0].value += char;
-          const changeEvent = new Event('change', {
+          const inputEvent = new Event('input', {
             bubbles: true,
             cancelable: true,
             composed: true,
           });
-          subject[0].dispatchEvent(changeEvent);
+          subject[0].dispatchEvent(inputEvent);
 
           setTimeout(resolve, delay);
         });
       }),
-    ).then(() => subject);
+    )
+      .then(
+        () =>
+          new Promise(resolve => {
+            const changeEvent = new Event('change', {
+              bubbles: true,
+              cancelable: true,
+              composed: true,
+            });
+            subject[0].dispatchEvent(changeEvent);
+
+            setTimeout(resolve, delay);
+          }),
+      )
+      .then(() => subject);
   });
 };


### PR DESCRIPTION
Change the event dispatching of `shadowType` so that it sends `input`
for each keystroke and `change` upon completion. Quoting MDN:

> The input event is fired every time the value of the element changes.
> This is unlike the change event, which only fires when the value is
> committed, such as by pressing the enter key, selecting a value from a
> list of options, and the like.

https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event

Fixes an issue where a shadow DOM input element rendered by Preact was
not updating its state.